### PR TITLE
instr_size fixes for arm64 #11162 rebased

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
          '${{ github.event.repository.full_name }}'
       - name: Configure tree
         run: |
-          MAKE_ARG=-j CONFIG_ARG='--enable-flambda --enable-cmm-invariants --enable-dependency-generation --enable-native-toplevel' OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh configure
+          MAKE_ARG=-j CONFIG_ARG='--enable-flambda --enable-cmm-invariants --enable-codegen-invariants --enable-dependency-generation --enable-native-toplevel' OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh configure
       - name: Build
         run: |
           MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh build
@@ -188,7 +188,7 @@ jobs:
 
       - name: configure tree
         run: |
-          CONFIG_ARG='${{ matrix.config_arg }}' MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh configure
+          CONFIG_ARG='--enable-codegen-invariants ${{ matrix.config_arg }}' MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh configure
       - name: Build
         run: |
           MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh build

--- a/Changes
+++ b/Changes
@@ -91,6 +91,10 @@ Working version
   (Pierre Chambart, review by Gabriel Scherer and Xavier Leroy,
    report by Patrick Nicodemus)
 
+- #13667: (originally #11162) Fix instr_size computation on arm64.
+  (Stephen Dolan and Tim McGilchrist, review by Xavier Leroy
+  and David Allsopp)
+
 ### Standard library:
 
 - #13729: Add Either.retract

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -213,6 +213,7 @@ HOST=@host@
 FLAMBDA=@flambda@
 WITH_FLAMBDA_INVARIANTS=@flambda_invariants@
 WITH_CMM_INVARIANTS=@cmm_invariants@
+WITH_CODEGEN_INVARIANTS=@codegen_invariants@
 FORCE_SAFE_STRING=true
 DEFAULT_SAFE_STRING=true
 WINDOWS_UNICODE=@windows_unicode@

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -407,7 +407,7 @@ let max_out_of_line_code_offset ~num_call_gc ~num_check_bound =
     max_offset
   end
 
-module BR = Branch_relaxation.Make (struct
+module Size = struct
   (* CR-someday mshinwell: B and BL have +/- 128Mb ranges; for the moment we
      assume we will never exceed this.  It would seem to be most likely to
      occur for branches between functions; in this case, the linker should be
@@ -449,12 +449,27 @@ module BR = Branch_relaxation.Make (struct
 
   let offset_pc_at_branch = 0
 
+  let addsub_size n =
+    let m = abs n in
+    assert (m < 0x1_000_000);
+    let ml = m land 0xFFF and mh = m land 0xFFF_000 in
+    max 1 ((if mh <> 0 then 1 else 0) +
+           (if ml <> 0 then 1 else 0))
+
+  let stack_adj_size n =
+    (* see emit_stack_adjustment *)
+    addsub_size n
+
   let prologue_size f =
-    (if initial_stack_offset f > 0 then 2 else 0)
-      + (if f.fun_frame_required then (if fp then 2 else 1) else 0)
+    let stk = initial_stack_offset f in
+    (if stk > 0 then stack_adj_size (-stk) else 0)
+    + (if f.fun_frame_required then (if fp then 2 else 1) else 0)
 
   let epilogue_size f =
-    if f.fun_frame_required then 3 else 2
+    let stk = initial_stack_offset f in
+    (if stk > 0 then stack_adj_size stk else 0) +
+    (if f.fun_frame_required then 1 else 0) +
+    1
 
   let instr_size f = function
     | Lend -> 0
@@ -462,7 +477,8 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Imove | Ispill | Ireload) -> 1
     | Lop (Iconst_int n) ->
       num_instructions_for_intconst n
-    | Lop (Iconst_float _) -> 2
+    | Lop (Iconst_float f) ->
+       if f = 0L || is_immediate_float f then 1 else 2
     | Lop (Iconst_symbol _) -> 2
     | Lop (Icall_ind) -> 1
     | Lop (Icall_imm _) -> 1
@@ -472,8 +488,8 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Iextcall {alloc; stack_ofs} ) ->
       if stack_ofs > 0 then 5
       else if alloc then 3
-      else 7
-    | Lop (Istackoffset _) -> 2
+      else 5
+    | Lop (Istackoffset n) -> stack_adj_size (-n)
     | Lop (Iload  { memory_chunk; addressing_mode; is_atomic }) ->
       let based = match addressing_mode with Iindexed _ -> 0 | Ibased _ -> 1
       and barrier = if is_atomic then 1 else 0
@@ -489,13 +505,15 @@ module BR = Branch_relaxation.Make (struct
       based + barrier + single
     | Lop (Ialloc _) when f.fun_fast -> 5
     | Lop (Ispecific (Ialloc_far _)) when f.fun_fast -> 6
-    | Lop (Ipoll _) -> 3
-    | Lop (Ispecific (Ipoll_far _)) -> 4
+    | Lop (Ipoll {return_label=None}) -> 3
+    | Lop (Ipoll {return_label=Some _}) -> 4
+    | Lop (Ispecific (Ipoll_far {return_label=None})) -> 4
+    | Lop (Ispecific (Ipoll_far {return_label=Some _})) -> 5
     | Lop (Ialloc { bytes = num_bytes; _ })
     | Lop (Ispecific (Ialloc_far { bytes = num_bytes; _ })) ->
       begin match num_bytes with
-      | 16 | 24 | 32 -> 1
-      | _ -> 1 + num_instructions_for_intconst (Nativeint.of_int num_bytes)
+      | 16 | 24 | 32 -> 2
+      | _ -> 2 + num_instructions_for_intconst (Nativeint.of_int num_bytes)
       end
     | Lop (Iintop (Icomp _)) -> 2
     | Lop (Icompf _) -> 2
@@ -508,6 +526,7 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Ispecific (Ishiftcheckbound_far _)) -> 3
     | Lop (Iintop Imod) -> 2
     | Lop (Iintop Imulh) -> 1
+    | Lop (Iintop_imm ((Iadd|Isub), n)) -> addsub_size n
     | Lop (Iintop _) -> 1
     | Lop (Iintop_imm _) -> 1
     | Lop (Ifloatofint | Iintoffloat | Iabsf | Inegf | Ispecific Isqrtf) -> 1
@@ -568,7 +587,8 @@ module BR = Branch_relaxation.Make (struct
     | Ishiftcheckbound { shift; } ->
       Lop (Ispecific (Ishiftcheckbound_far { shift; }))
     | _ -> assert false
-end)
+end
+module BR = Branch_relaxation.Make (Size)
 
 (* Output the assembly code for allocation. *)
 
@@ -1073,8 +1093,33 @@ let emit_instr env i =
 
 (* Emission of an instruction sequence *)
 
-let rec emit_all env i =
-  if i.desc = Lend then () else (emit_instr env i; emit_all env i.next)
+(* for debugging instr_size errors *)
+let emit_instr_debug env i =
+  let lbl = new_label () in
+  `{emit_label lbl}:\n`;
+  emit_instr env i;
+  let sz = Size.instr_size env.f i.desc * 4 in
+  `	.ifne (. - {emit_label lbl}) - {emit_int sz}\n`;
+  `	.error \"Emit.instr_size: instruction length mismatch\"\n`;
+  `	.endif\n`
+
+let rec emit_all env lbl_start acc i =
+  match i.desc with
+  | Lend ->
+     (* acc measures in units of 32-bit instructions *)
+     let sz = acc * 4 in
+     `	.ifne (. - {emit_label lbl_start}) - {emit_int sz}\n`;
+     `	.error \"Emit.instr_size: instruction length mismatch\"\n`;
+     `	.endif\n`;
+  | _ ->
+     let debug = false in
+     if debug then emit_instr_debug env i else emit_instr env i;
+     emit_all env lbl_start (acc + Size.instr_size env.f i.desc) i.next
+
+let emit_all env i =
+  let lbl = new_label () in
+  `{emit_label lbl}:\n`;
+  emit_all env lbl 0 i
 
 (* Emission of a function declaration *)
 

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -1104,15 +1104,19 @@ let emit_instr_debug env i =
   `	.endif\n`
 
 let rec emit_all env lbl_start acc i =
+  let debug = Config.with_codegen_invariants in
   match i.desc with
   | Lend ->
-     (* acc measures in units of 32-bit instructions *)
-     let sz = acc * 4 in
-     `	.ifne (. - {emit_label lbl_start}) - {emit_int sz}\n`;
-     `	.error \"Emit.instr_size: instruction length mismatch\"\n`;
-     `	.endif\n`;
+     if debug then begin
+       (* acc measures in units of 32-bit instructions *)
+       let sz = acc * 4 in
+       `	.ifne (. - {emit_label lbl_start}) - {emit_int sz}\n`;
+       `	.error \"Emit.instr_size: instruction length mismatch\"\n`;
+       `	.endif\n`;
+       end
+     else
+       ()
   | _ ->
-     let debug = false in
      if debug then emit_instr_debug env i else emit_instr env i;
      emit_all env lbl_start (acc + Size.instr_size env.f i.desc) i.next
 

--- a/configure
+++ b/configure
@@ -862,6 +862,7 @@ otherlibs
 otherlibraries
 instrumented_runtime_libs
 instrumented_runtime
+codegen_invariants
 debug_runtime
 cmxs
 natdynlink_archive
@@ -998,6 +999,7 @@ ac_subst_files=''
 ac_user_opts='
 enable_option_checking
 enable_debug_runtime
+enable_codegen_invariants
 enable_ocamldebug
 enable_debugger
 enable_dependency_generation
@@ -1697,6 +1699,8 @@ Optional Features:
   --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
   --disable-debug-runtime do not build runtime with debugging support
+  --enable-codegen-invariants
+                          enable invariants checks in native codegen
   --enable-ocamldebug     build ocamldebug [default=auto]
   --enable-debugger       alias for --enable-ocamldebug
   --disable-dependency-generation
@@ -3500,6 +3504,7 @@ LINEAR_MAGIC_NUMBER=Caml1999L035
 
 
 
+
  # TODO: rename this variable
 
 
@@ -3866,6 +3871,13 @@ fi
 if test ${enable_debug_runtime+y}
 then :
   enableval=$enable_debug_runtime;
+fi
+
+
+# Check whether --enable-codegen-invariants was given.
+if test ${enable_codegen_invariants+y}
+then :
+  enableval=$enable_codegen_invariants;
 fi
 
 
@@ -21662,6 +21674,14 @@ case $enable_debug_runtime in #(
     debug_runtime=false ;; #(
   *) :
     debug_runtime=true ;;
+esac
+
+## Should the codegen with debugging support be built
+case $enable_codegen_invariants in #(
+  no) :
+    codegen_invariants=false ;; #(
+  *) :
+    codegen_invariants=true ;;
 esac
 
 ## Determine how to link with the POSIX threads library

--- a/configure.ac
+++ b/configure.ac
@@ -196,6 +196,7 @@ AC_SUBST([natdynlinkopts])
 AC_SUBST([natdynlink_archive])
 AC_SUBST([cmxs])
 AC_SUBST([debug_runtime])
+AC_SUBST([codegen_invariants])
 AC_SUBST([instrumented_runtime])
 AC_SUBST([instrumented_runtime_libs])
 AC_SUBST([otherlibraries])
@@ -377,6 +378,10 @@ AC_ARG_VAR([COMPILER_NATIVE_CPPFLAGS],
 AC_ARG_ENABLE([debug-runtime],
   [AS_HELP_STRING([--disable-debug-runtime],
     [do not build runtime with debugging support])])
+
+AC_ARG_ENABLE([codegen-invariants],
+  [AS_HELP_STRING([--enable-codegen-invariants],
+    [enable invariants checks in native codegen])])
 
 AC_ARG_ENABLE([ocamldebug],
   [AS_HELP_STRING([--enable-ocamldebug],
@@ -2438,6 +2443,11 @@ AS_CASE([$enable_ocamldebug],
 AS_CASE([$enable_debug_runtime],
   [no], [debug_runtime=false],
   [debug_runtime=true])
+
+## Should the codegen with debugging support be built
+AS_CASE([$enable_codegen_invariants],
+  [no], [codegen_invariants=false],
+  [codegen_invariants=true])
 
 ## Determine how to link with the POSIX threads library
 

--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -155,7 +155,7 @@ conffile=Makefile.config
 make=make
 instdir="$HOME/ocaml-tmp-install"
 confoptions="--enable-ocamltest --enable-dependency-generation \
-${OCAML_CONFIGURE_OPTIONS}"
+--enable-codegen-invariants ${OCAML_CONFIGURE_OPTIONS}"
 make_native=true
 cleanup=false
 check_make_alldepend=false

--- a/utils/config.common.ml.in
+++ b/utils/config.common.ml.in
@@ -124,6 +124,7 @@ let configuration_variables () =
   p_bool "supports_shared_libraries" supports_shared_libraries;
   p_bool "native_dynlink" native_dynlink;
   p_bool "naked_pointers" naked_pointers;
+  p_bool "with_codegen_invariants" with_codegen_invariants;
 
   p "exec_magic_number" exec_magic_number;
   p "cmi_magic_number" cmi_magic_number;

--- a/utils/config.fixed.ml
+++ b/utils/config.fixed.ml
@@ -49,6 +49,7 @@ let mkmaindll = native_pack_linker
 let flambda = false
 let with_flambda_invariants = false
 let with_cmm_invariants = false
+let with_codegen_invariants = false
 let windows_unicode = false
 let flat_float_array = true
 let align_double = true

--- a/utils/config.generated.ml.in
+++ b/utils/config.generated.ml.in
@@ -59,6 +59,7 @@ let mkmaindll = {@QS@|@mkmaindll_exp@|@QS@}
 let flambda = @flambda@
 let with_flambda_invariants = @flambda_invariants@
 let with_cmm_invariants = @cmm_invariants@
+let with_codegen_invariants = @codegen_invariants@
 let windows_unicode = @windows_unicode@ != 0
 
 let flat_float_array = @flat_float_array@

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -227,6 +227,9 @@ val with_flambda_invariants : bool
 val with_cmm_invariants : bool
 (** Whether the invariants checks for Cmm are enabled *)
 
+val with_codegen_invariants : bool
+(** Whether the invariant checks for native code generation are enabled. *)
+
 val reserved_header_bits : int
 (** How many bits of a block's header are reserved *)
 


### PR DESCRIPTION
Rebased version of PR 11162 with an extra configure option to enable or disable the instruction size checks on the ARM64 backend. This option is enabled for GitHub CI workflow.

Testing using `opam compiler create https://github.com/tmcgilchrist/ocaml/pull/20 --configure-command "./configure --enable-debug-codegen"`