### PR TITLE
Fixes for CFI information in s390x.

### DIFF
--- a/Changes
+++ b/Changes
@@ -29,7 +29,10 @@ Working version
 ### Build system:
 
 ### Bug fixes:
-
+- #14500: Fix CFI information emitted for s390x architecture. This helps
+  debuggers to unwind the stack correctly and print accurate backtraces
+  for OCaml code.
+  (Tim McGilchrist, review by ?????)
 
 OCaml 5.5.0
 -----------

--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -429,6 +429,15 @@ let cfi_def_cfa_register ~reg =
     emit_string "\n"
   end
 
+let cfi_val_offset ~reg ~offset =
+  if is_cfi_enabled () then begin
+    emit_string "\t.cfi_escape 0x14, "; (* DW_CFA_val_offset (0x14) *)
+    emit_int reg;
+    emit_string ", ";
+    emit_int offset;
+    emit_string "\n"
+  end
+
 (* Emit debug information *)
 
 (* This assoc list is expected to be very short *)

--- a/asmcomp/emitaux.mli
+++ b/asmcomp/emitaux.mli
@@ -87,6 +87,7 @@ val cfi_def_cfa_offset : int -> unit
 val cfi_remember_state : unit -> unit
 val cfi_restore_state : unit -> unit
 val cfi_def_cfa_register: reg:int -> unit
+val cfi_val_offset: reg:int -> offset:int -> unit
 
 val binary_backend_available: bool ref
     (** Is a binary backend available.  If yes, we don't need

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -88,23 +88,6 @@ let reg_r7 = check_phys_reg 5 "%r7"
 let reg_stack_arg_begin = check_phys_reg 7 "%r9"
 let reg_stack_arg_end = check_phys_reg 6 "%r8"
 
-let cfi_startproc () =
-  if Config.asm_cfi_supported then begin
-    emit_string "\t.cfi_startproc\n";
-  end
-
-let cfi_endproc () =
-  if Config.asm_cfi_supported then begin
-    emit_string "\t.cfi_endproc\n";
-  end
-
-let cfi_def_cfa_register reg =
-  if Config.asm_cfi_supported then begin
-    emit_string "\t.cfi_def_cfa_register ";
-    emit_string reg;
-    emit_string "\n"
-  end
-
 (* Output a stack reference *)
 
 let emit_stack env r =
@@ -301,8 +284,15 @@ let emit_instr env i =
     | Lprologue ->
       let n = frame_size env in
       emit_stack_adjust n;
-      if env.f.fun_frame_required then
-        `	stg	%r14, {emit_int(n - size_addr)}(%r15)\n`
+      (* Use cfi_def_cfa_offset to SET the CFA, not adjust it.
+         The s390x CIE has a default offset of 160 for C ABI, but OCaml
+         has its own stack layout. CFA = sp + n after allocation. *)
+      cfi_def_cfa_offset n;
+      cfi_val_offset ~reg:15 ~offset:0;
+      if env.f.fun_frame_required then begin
+        `	stg	%r14, {emit_int(n - size_addr)}(%r15)\n`;
+        cfi_offset ~reg:14 ~offset:(-size_addr)
+      end
     | Lop(Imove | Ispill | Ireload) ->
         let src = i.arg.(0) and dst = i.res.(0) in
         if src.loc <> dst.loc then begin
@@ -381,10 +371,7 @@ let emit_instr env i =
           (* Save OCaml SP in C callee-save register *)
           `	lgr	%r12, %r15\n`;
           cfi_remember_state ();
-          cfi_def_cfa_register "%r12";
-          (* NB: gdb has asserts on contiguous stacks that mean it
-             will not unwind through this unless we were to tag this
-             calling frame with cfi_signal_frame in its definition. *)
+          cfi_def_cfa_register ~reg:12;
           let offset = Domainstate.(idx_of_field Domain_c_stack) * 8 in
           `	lg	%r15, {emit_int offset}(%r10)\n`;
           emit_call func;
@@ -394,6 +381,7 @@ let emit_instr env i =
 
      | Lop(Istackoffset n) ->
         emit_stack_adjust n;
+        if n <> 0 then cfi_adjust_cfa_offset n;
         env.stack_offset <- env.stack_offset + n
 
      | Lop(Iload { memory_chunk; addressing_mode; _ }) ->
@@ -674,10 +662,12 @@ let emit_instr env i =
         (* each trap occupies 16 bytes on the stack *)
         let delta = 16 * delta_traps in
         emit_stack_adjust delta;
+        if delta <> 0 then cfi_adjust_cfa_offset delta;
         env.stack_offset <- env.stack_offset + delta
     | Lpushtrap { lbl_handler; } ->
         env.stack_offset <- env.stack_offset + 16;
         emit_stack_adjust 16;
+        cfi_adjust_cfa_offset 16;
         `	larl	%r14, {emit_label lbl_handler}\n`;
         `	stg	%r14, {emit_int size_addr}(%r15)\n`;
         `	stg	%r13, 0(%r15)\n`;
@@ -685,6 +675,7 @@ let emit_instr env i =
     | Lpoptrap ->
         `	lg	%r13, 0(%r15)\n`;
         emit_stack_adjust (-16);
+        cfi_adjust_cfa_offset (-16);
         env.stack_offset <- env.stack_offset - 16
     | Lraise k ->
         begin match k with
@@ -723,6 +714,10 @@ let fundecl fundecl =
   `	.align	8\n`;
   `{emit_symbol fundecl.fun_name}:\n`;
   cfi_startproc ();
+  (* Reset CFA from CIE default (r15+160) to r15+0 at function entry.
+     This ensures correct unwinding even when stopped before the prologue. *)
+  cfi_def_cfa_offset 0;
+  cfi_val_offset ~reg:15 ~offset:0;
 
   (* Dynamic stack checking *)
   let stack_threshold_size = Config.stack_threshold * 8 in (* bytes *)
@@ -753,11 +748,18 @@ let fundecl fundecl =
       `{emit_label overflow}:\n`;
       let s = (Config.stack_threshold + max_frame_size / 8) in
       `	lay	%r15, -8(%r15)\n`;
+      (* Set CFA = sp + 8 after allocating 8 bytes *)
+      cfi_def_cfa_offset 8;
+      cfi_val_offset ~reg:15 ~offset:0;
       `	stg	%r14, 0(%r15)\n`;
+      cfi_offset ~reg:14 ~offset:(-8);
       `	lgfi	%r12, {emit_int s}\n`;
       emit_call "caml_call_realloc_stack";
       `	lg	%r14, 0(%r15)\n`;
       `	la	%r15, 8(%r15)\n`;
+      (* Back to entry state: CFA = sp + 0 *)
+      cfi_def_cfa_offset 0;
+      cfi_val_offset ~reg:15 ~offset:0;
       `	brcl	15, {emit_label ret}\n`
     end
   end;

--- a/runtime/caml/asm.h
+++ b/runtime/caml/asm.h
@@ -77,6 +77,7 @@
  */
 
 #define DW_CFA_def_cfa_expression 0x0f
+#define DW_CFA_val_offset         0x14
 #define DW_OP_breg                0x70
 #define DW_OP_deref               0x06
 #define DW_OP_plus_uconst         0x23

--- a/runtime/s390x.S
+++ b/runtime/s390x.S
@@ -78,12 +78,14 @@ caml_hot.code_end:
 /* Stack space to be reserved by the caller of a C function */
 #define RESERVED_STACK          160
 
-/* special sleb128 constants, precalculated */
-/* Cstack_sp + 160 = 8 + 160 = 168, encoded as sleb128 */
-#define Cstack_sp_plus_160_sleb128_2byte 168, 1
+/* SLEB128-encoded constants for .cfi_escape directives. */
 
-/* struct c_stack_link + callee save regs = 24 + 8*8 = 88 */
-#define start_program_sleb128_2byte 216, 0
+/* Cstack_sp = structure offset (8) + reserved area (160) = 168 */
+#define Cstack_sp_sleb128_2byte 168, 1
+
+/* From C_STACK_SP to entry_sp: entry_sp - (entry_sp - 344) = 344
+   CFA = *(r15+16) + 344 = (entry_sp - 344) + 344 = entry_sp (caller's sp) */
+#define start_program_sleb128_2byte 216, 2
 
 /* exception handler + gc_regs slot + C_STACK_SP + Handler_parent
    = 16 + 8 + 8 + 24 = 56 */
@@ -96,7 +98,8 @@ caml_hot.code_end:
 #define ENTER_FUNCTION \
         lay     %r15, -8(%r15); \
         CFI_ADJUST(8); \
-        stg     %r14, 0(%r15)
+        stg     %r14, 0(%r15); \
+        CFI_OFFSET(14, -168)
 
 #define LEAVE_FUNCTION \
         lg      %r14, 0(%r15); \
@@ -176,10 +179,12 @@ caml_system__code_begin:
 #ifdef ASM_CFI_SUPPORTED
 #define SWITCH_OCAML_TO_C_CFI                                   \
         CFI_REMEMBER_STATE;                                     \
-        CFI_OFFSET(14, 0); \
-          /* %r15 points to the c_stack_link. */                \
-        .cfi_escape DW_CFA_def_cfa_expression, 3,               \
-          DW_OP_breg + DW_REG_r15, Cstack_sp, DW_OP_deref
+        /* CFA = *(r15+168) + 8 = saved_sp + 8 = caller's original sp */ \
+        .cfi_escape DW_CFA_def_cfa_expression, 6,               \
+          DW_OP_breg + DW_REG_r15, Cstack_sp_sleb128_2byte, DW_OP_deref, \
+          DW_OP_plus_uconst, 8;                                 \
+        CFI_OFFSET(14, -8);                                     \
+        .cfi_escape DW_CFA_val_offset, DW_REG_r15, 0
 #else
 #define SWITCH_OCAML_TO_C_CFI
 #endif
@@ -395,14 +400,15 @@ FUNCTION(G(caml_call_realloc_stack))
 CFI_STARTPROC
         CFI_SIGNAL_FRAME
         ENTER_FUNCTION
-        CFI_OFFSET(14, -168)
         SAVE_ALL_REGS
         lgr    C_ARG_1, %r12 /* requested size */
         SWITCH_OCAML_TO_C
         PREPARE_FOR_C_CALL
 #ifdef ASM_CFI_SUPPORTED
-        .cfi_escape DW_CFA_def_cfa_expression, 4, DW_OP_breg + DW_REG_r15, \
-          Cstack_sp_plus_160_sleb128_2byte, DW_OP_deref
+        .cfi_escape DW_CFA_def_cfa_expression, 6, DW_OP_breg + DW_REG_r15, \
+          Cstack_sp_sleb128_2byte, DW_OP_deref, DW_OP_plus_uconst, 8
+        CFI_OFFSET(14, -8)
+        .cfi_escape DW_CFA_val_offset, DW_REG_r15, 0
 #endif
         brasl %r14, GCALL(caml_try_realloc_stack)
         CLEANUP_AFTER_C_CALL
@@ -425,14 +431,15 @@ CFI_STARTPROC
 LBL(caml_call_gc):
         CFI_SIGNAL_FRAME
         ENTER_FUNCTION
-        CFI_OFFSET(14, -168)
         SAVE_ALL_REGS
         TSAN_ENTER_FUNCTION
         SWITCH_OCAML_TO_C
         PREPARE_FOR_C_CALL
 #ifdef ASM_CFI_SUPPORTED
-        .cfi_escape DW_CFA_def_cfa_expression, 4, DW_OP_breg + DW_REG_r15, \
-          Cstack_sp_plus_160_sleb128_2byte, DW_OP_deref
+        .cfi_escape DW_CFA_def_cfa_expression, 6, DW_OP_breg + DW_REG_r15, \
+          Cstack_sp_sleb128_2byte, DW_OP_deref, DW_OP_plus_uconst, 8
+        CFI_OFFSET(14, -8)
+        .cfi_escape DW_CFA_val_offset, DW_REG_r15, 0
 #endif
         brasl %r14, GCALL(caml_garbage_collection)
         CLEANUP_AFTER_C_CALL
@@ -495,7 +502,6 @@ FUNCTION(G(caml_c_call))
 CFI_STARTPROC
         CFI_SIGNAL_FRAME
         ENTER_FUNCTION
-        CFI_OFFSET(14, -168)
         TSAN_SAVE_CALLER_REGS
         TSAN_ENTER_FUNCTION
         TSAN_RESTORE_CALLER_REGS
@@ -511,8 +517,10 @@ LBL(caml_c_call):
     /* Call the function (address in ADDITIONAL_ARG) */
         PREPARE_FOR_C_CALL
 #ifdef ASM_CFI_SUPPORTED
-        .cfi_escape DW_CFA_def_cfa_expression, 4, DW_OP_breg + DW_REG_r15, \
-          Cstack_sp_plus_160_sleb128_2byte, DW_OP_deref
+        .cfi_escape DW_CFA_def_cfa_expression, 6, DW_OP_breg + DW_REG_r15, \
+          Cstack_sp_sleb128_2byte, DW_OP_deref, DW_OP_plus_uconst, 8
+        CFI_OFFSET(14, -8)
+        .cfi_escape DW_CFA_val_offset, DW_REG_r15, 0
 #endif
         basr    %r14, ADDITIONAL_ARG
         CLEANUP_AFTER_C_CALL
@@ -534,7 +542,6 @@ FUNCTION(G(caml_c_call_stack_args))
 CFI_STARTPROC
         CFI_SIGNAL_FRAME
         ENTER_FUNCTION
-        CFI_OFFSET(14, -168)
     /* Arguments:
         C arguments         : %r2, %r3, %r4, %r5, %r6
         C function          : ADDITIONAL_ARG
@@ -554,9 +561,12 @@ CFI_STARTPROC
     /* Store sp to restore after call */
         lgr     %r12, %r15
 #ifdef ASM_CFI_SUPPORTED
-        .cfi_escape DW_CFA_def_cfa_expression, 3,           \
+        .cfi_escape DW_CFA_def_cfa_expression, 6,           \
           /* %r12 points to the c_stack_link structure */   \
-          DW_OP_breg + DW_REG_r12, Cstack_sp, DW_OP_deref
+          DW_OP_breg + DW_REG_r12, Cstack_sp_sleb128_2byte, DW_OP_deref, \
+          DW_OP_plus_uconst, 8
+        CFI_OFFSET(14, -8)
+        .cfi_escape DW_CFA_val_offset, DW_REG_r15, 0
 #endif
     /* Copy arguments from OCaml to C stack, always reserving
        the 160 bytes at the bottom of the C stack. */
@@ -621,8 +631,9 @@ LBL(caml_start_program):
         lay     %r15, -RESERVED_STACK(%r15)
     /* Save all callee-save registers + return address */
     /* GPR 6..14 at sp + 0 ... sp + 64
-       FPR 10..15 at sp + 72 ... sp + 128 */
+       FPR 8..15 at sp + 72 ... sp + 128 */
         stmg    %r6,%r14, 0(%r15)
+    /* r14 is at sp + 64 = entry_sp - 96. CFA = entry_sp, so offset = -96 */
         CFI_OFFSET(14, 64 - RESERVED_STACK)
         std     %f8, 72(%r15)
         std     %f9, 80(%r15)
@@ -667,12 +678,14 @@ LBL(caml_start_program):
         lgr     %r15, %r8
 #ifdef ASM_CFI_SUPPORTED
         CFI_REMEMBER_STATE
-        CFI_OFFSET(14, 0)
+        /* CFA = entry_sp (via cfi_escape below), r14 is at entry_sp - 96 */
+        CFI_OFFSET(14, -96)
         .cfi_escape DW_CFA_def_cfa_expression, 3 + 3,                 \
             /* %r15 points to the exn handler on the OCaml stack */   \
             /* %r15 + 16 contains the C_STACK_SP */                   \
           DW_OP_breg + DW_REG_r15, 16 /* exn handler */, DW_OP_deref, \
           DW_OP_plus_uconst, start_program_sleb128_2byte
+        .cfi_escape DW_CFA_val_offset, DW_REG_r15, 0
 #endif
         basr    %r14, TMP
 LBL(caml_retaddr):
@@ -695,7 +708,7 @@ LBL(return_result):  /* restore GC regs */
         lg      %r8, Cstack_prev(%r15)
         stg     %r8, Caml_state(c_stack)
         la      %r15, SIZEOF_C_STACK_LINK(%r15)
-        CFI_ADJUST(SIZEOF_C_STACK_LINK)
+        CFI_ADJUST(-SIZEOF_C_STACK_LINK)
 #if defined(WITH_THREAD_SANITIZER)
     /* We can't use TSAN_EXIT_FUNCTION here, as it assumes to run on an
        OCaml stack, and we are back to a C stack at this point. */
@@ -1111,7 +1124,6 @@ CFI_STARTPROC
 #endif
         CFI_SIGNAL_FRAME
         ENTER_FUNCTION
-        CFI_OFFSET(14, -168)
     /* %r2 -> fiber, %r3 -> fun, %r4 -> arg */
         lay     %r2, -1(%r2)  /* %r2 (new stack) = Ptr_val(%r2) */
         lg      %r5,  0(%r3)  /* code pointer */
@@ -1143,6 +1155,7 @@ CFI_STARTPROC
           DW_OP_deref,                                \
           DW_OP_plus_uconst, Stack_sp, DW_OP_deref,   \
           DW_OP_plus_uconst, RETADDR_ENTRY_SIZE
+        .cfi_escape DW_CFA_val_offset, DW_REG_r15, 0
 #endif
     /* Call the function on the new stack */
         lgr     %r2, %r4 /* first argument */
@@ -1199,7 +1212,6 @@ ENDFUNCTION(G(caml_runstack))
 FUNCTION(G(caml_ml_array_bound_error))
 CFI_STARTPROC
         ENTER_FUNCTION
-        CFI_OFFSET(14, -168)
     /* No registers require saving before C call to TSan */
         TSAN_ENTER_FUNCTION
         LEA_VAR(caml_array_bound_error_asm, ADDITIONAL_ARG)

--- a/testsuite/tests/native-debugger/linux-gdb-s390x.ml
+++ b/testsuite/tests/native-debugger/linux-gdb-s390x.ml
@@ -1,0 +1,20 @@
+(* TEST
+   native-compiler;
+   no-tsan; (* Skip, TSan inserts extra frames into backtraces *)
+   linux;
+   not-clang;
+   arch_s390x;
+   script = "sh ${test_source_directory}/has_gdb.sh";
+   script;
+   readonly_files = "meander.ml meander_c.c gdb_test.py";
+   setup-ocamlopt.byte-build-env;
+   program = "${test_build_directory}/meander";
+   flags = "-g -ccopt -O0";
+   all_modules = "meander.ml meander_c.c";
+   ocamlopt.byte;
+   debugger_script = "${test_source_directory}/gdb-script";
+   gdb;
+   script = "sh ${test_source_directory}/sanitize.sh linux-gdb-s390x";
+   script;
+   check-program-output;
+ *)

--- a/testsuite/tests/native-debugger/linux-gdb-s390x.reference
+++ b/testsuite/tests/native-debugger/linux-gdb-s390x.reference
@@ -1,0 +1,54 @@
+Breakpoint 1 at 0x00000000000000
+Breakpoint 2 at 0x00000000000000
+Breakpoint 3 at 0x00000000000000: file meander_c.c, line XXX.
+Breakpoint 4 at 0x00000000000000: file meander.ml, line XXX.
+Breakpoint 1, <signal handler called>
+frame 0: caml_start_program
+frame 1: caml_startup_common
+frame 2: caml_startup_common
+frame 3: caml_startup_exn
+frame 4: caml_startup
+frame 5: caml_main
+frame 6: main
+Breakpoint 2, 0x00000000000000 in caml_program ()
+frame 0: caml_program
+frame 1: caml_start_program
+frame 2: caml_startup_common
+frame 3: caml_startup_common
+frame 4: caml_startup_exn
+frame 5: caml_startup
+frame 6: caml_main
+frame 7: main
+Breakpoint 3, ocaml_to_c (unit=1) at meander_c.c:XX
+5	    caml_callback(*caml_named_value
+frame 0: ocaml_to_c
+frame 1: caml_c_call
+frame 2: camlMeander.omain
+frame 3: camlMeander.entry
+frame 4: caml_program
+frame 5: caml_start_program
+frame 6: caml_startup_common
+frame 7: caml_startup_common
+frame 8: caml_startup_exn
+frame 9: caml_startup
+frame 10: caml_main
+frame 11: main
+Breakpoint 4, camlMeander.c_to_ocaml () at meander.ml:5
+5	let c_to_ocaml () = raise E1
+frame 0: camlMeander.c_to_ocaml
+frame 1: caml_start_program
+frame 2: caml_callback_exn
+frame 3: caml_callback
+frame 4: ocaml_to_c
+frame 5: caml_c_call
+frame 6: camlMeander.omain
+frame 7: camlMeander.entry
+frame 8: caml_program
+frame 9: caml_start_program
+frame 10: caml_startup_common
+frame 11: caml_startup_common
+frame 12: caml_startup_exn
+frame 13: caml_startup
+frame 14: caml_main
+frame 15: main
+[Inferior 1 (process XXXX) exited normally]


### PR DESCRIPTION
This helps gdb/lldb to unwind the stack correctly and print accurate backtraces for OCaml code.