### PR TITLE
Detect Linux ppc64 and test arch correctly.

### DIFF
--- a/configure
+++ b/configure
@@ -18960,6 +18960,8 @@ case $target in #(
     has_native_backend=yes; arch=power; model=ppc64le; system=linux ;; #(
   powerpc64*-*-linux-musl*) :
     has_native_backend=yes; arch=power; model=ppc64; system=linux ;; #(
+  powerpc64*-*-linux*) :
+    arch=power; model=ppc64; system=linux ;; #(
   s390x*-*-linux*) :
     has_native_backend=yes; arch=s390x; model=z10; system=linux ;; #(
   # expected to match "gnueabihf" as well as "musleabihf"

--- a/configure.ac
+++ b/configure.ac
@@ -1656,6 +1656,8 @@ AS_CASE([$target],
     [has_native_backend=yes; arch=power; model=ppc64le; system=linux],
   [[powerpc64*-*-linux-musl*]],
     [has_native_backend=yes; arch=power; model=ppc64; system=linux],
+  [[powerpc64*-*-linux*]],
+    [arch=power; model=ppc64; system=linux],
   [[s390x*-*-linux*]],
     [has_native_backend=yes; arch=s390x; model=z10; system=linux],
   # expected to match "gnueabihf" as well as "musleabihf"


### PR DESCRIPTION
Matches Linux distros targeting ELFv1 (like debian) and correctly sets the arch configure variable, which gets used in ocamltest when detecting the architecture a test should run on.